### PR TITLE
Update game rules to allow placing stones in center spot with a maximum of 11 stones

### DIFF
--- a/game.js
+++ b/game.js
@@ -12,7 +12,8 @@
                 5: null, // left top point
                 6: null  // center
             },
-            gameOver: false
+            gameOver: false,
+            centerStones: 0 // Track the number of stones in the center spot
         };
 
         // Point positions (in percentages relative to the board)
@@ -83,6 +84,12 @@
             
             const status = document.getElementById('status');
             
+            if (roll === 6 && gameState.centerStones >= 11) {
+                status.textContent = `Player ${gameState.currentPlayer} rolled a 6, but the center spot already has 11 stones.`;
+                document.getElementById('roll-btn').disabled = false;
+                return;
+            }
+
             if (position === null) {
                 // Position is empty, player can place a stone
                 status.textContent = `Player ${gameState.currentPlayer} rolled a ${roll}. Click on position ${roll} to place your stone.`;
@@ -189,6 +196,13 @@
             
             // If position is empty, place a stone
             if (gameState.board[pointNumber] === null) {
+                // Check if the center spot already has 11 stones
+                if (pointNumber === 6 && gameState.centerStones >= 11) {
+                    const status = document.getElementById('status');
+                    status.textContent = `Player ${gameState.currentPlayer} cannot place a stone in the center spot (position 6) as it already has 11 stones.`;
+                    return;
+                }
+
                 gameState.board[pointNumber] = gameState.currentPlayer;
                 
                 // Decrease stone count for current player
@@ -198,6 +212,11 @@
                 } else {
                     gameState.player2Stones--;
                     document.getElementById('player2-stones').textContent = gameState.player2Stones;
+                }
+
+                // Increment centerStones if the stone is placed in the center spot
+                if (pointNumber === 6) {
+                    gameState.centerStones++;
                 }
                 
                 // Check win condition
@@ -269,6 +288,7 @@
             gameState.player2Stones = 6;
             gameState.currentRoll = null;
             gameState.gameOver = false;
+            gameState.centerStones = 0; // Reset the centerStones property
             
             // Clear the board
             for (let i = 1; i <= 6; i++) {

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
                 <li>Players roll a die on their turn.</li>
                 <li>If the rolled number corresponds to an empty position, the player places their stone there.</li>
                 <li>If the position is already occupied by any stone (their own or opponent's), the player must take that stone and add it to their total.</li>
-                <li>If a player rolls a 6, they can place a stone in the center spot (position 6).</li>
+                <li>If a player rolls a 6, they can place a stone in the center spot (position 6). The center spot can have a maximum of 11 stones at the same time.</li>
                 <li>The first player to place all their stones wins!</li>
             </ul>
         </div>


### PR DESCRIPTION
Update game logic to allow placing stones in the center spot (position 6) with a maximum of 11 stones.

* **game.js**
  - Add `centerStones` property to track the number of stones in the center spot.
  - Update `checkMoveAvailability` function to check if position 6 has less than 11 stones before allowing a player to place a stone there.
  - Update `handlePointClick` function to enforce the maximum of 11 stones in position 6 by checking the count before placing a stone.
  - Reset `centerStones` property when resetting the game state.

* **index.html**
  - Update the rules to specify that a player can place a stone in the center spot (position 6) if they roll a 6, with a maximum of 11 stones allowed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MrCodeBS/Up-to-the-Star/pull/4?shareId=ba04af5d-4a7a-460e-a956-0b2003b38f54).