### PR TITLE
Fix center spot counter increment issue

### DIFF
--- a/game.js
+++ b/game.js
@@ -96,6 +96,12 @@
                 return;
             }
 
+            if (roll === 6 && gameState.centerStones < 11) {
+                status.textContent = `Player ${gameState.currentPlayer} rolled a 6. Click on position 6 to place your stone.`;
+                highlightPoint(6);
+                return;
+            }
+
             if (position === null) {
                 // Position is empty, player can place a stone
                 status.textContent = `Player ${gameState.currentPlayer} rolled a ${roll}. Click on position ${roll} to place your stone.`;


### PR DESCRIPTION
Modify `checkMoveAvailability` function in `game.js` to prevent the player's counter from increasing when rolling a six if the center spot has less than 11 stones.

* Add a condition to check if the roll is six and the center spot has less than 11 stones.
* Update the status text content to inform the player to place the stone in position 6.
* Highlight position 6 for the player to click and place the stone.
* Return early to prevent further execution if the condition is met.

